### PR TITLE
replace fail module with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,13 +225,13 @@ dependencies = [
 name = "dockworker"
 version = "0.0.18"
 dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,6 +249,7 @@ dependencies = [
  "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,6 +758,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +776,14 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1068,6 +1090,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1150,24 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1335,6 +1385,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unix_socket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1504,7 @@ dependencies = [
 [metadata]
 "checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
@@ -1530,8 +1586,10 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
+"checksum proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
@@ -1569,11 +1627,14 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tar 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a303ba60a099fcd2aaa646b14d2724591a96a75283e4b7ed3d1a1658909d9ae2"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum thiserror 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
+"checksum thiserror-impl 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4790d0be6f4ba6ae4f48190efa2ed7780c9e3567796abdb285003cf39840d9c5"
@@ -1594,6 +1655,7 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,11 +17,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +220,6 @@ dependencies = [
 name = "dockworker"
 version = "0.0.18"
 dependencies = [
- "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1504,7 +1498,6 @@ dependencies = [
 [metadata]
 "checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
-"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ ssl = ["openssl", "native-tls", "hyper-tls"]
 
 [dependencies]
 chrono = "0.4.6"
-failure = "0.1.5"
+thiserror = "1.0"
+anyhow = "1.0"
 backtrace-sys = "=0.1.23"
 futures = "0.1"
 http = "0.1"
@@ -49,7 +50,7 @@ base64 = "0.9.2"
 dirs = "1.0.0"
 
 [dev-dependencies]
-failure = "0.1.5"
+anyhow = "1.0"
 env_logger = "0.5"
 rand = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ssl = ["openssl", "native-tls", "hyper-tls"]
 [dependencies]
 chrono = "0.4.6"
 thiserror = "1.0"
-anyhow = "1.0"
 backtrace-sys = "=0.1.23"
 futures = "0.1"
 http = "0.1"
@@ -50,7 +49,6 @@ base64 = "0.9.2"
 dirs = "1.0.0"
 
 [dev-dependencies]
-anyhow = "1.0"
 env_logger = "0.5"
 rand = "0.5"
 

--- a/examples/findports.rs
+++ b/examples/findports.rs
@@ -1,6 +1,5 @@
 extern crate dockworker;
 
-use anyhow::Error;
 use dockworker::errors::*;
 use dockworker::{ContainerListOptions, Docker};
 
@@ -21,11 +20,6 @@ fn find_all_exported_ports() -> Result<()> {
     Ok(())
 }
 
-fn main() {
-    if let Err(err) = find_all_exported_ports() {
-        eprint!("Error: ");
-        for e in Error::new(err).chain() {
-            eprintln!("{}", e);
-        }
-    }
+fn main() -> Result<()> {
+    find_all_exported_ports()
 }

--- a/examples/findports.rs
+++ b/examples/findports.rs
@@ -1,9 +1,8 @@
 extern crate dockworker;
-extern crate failure;
 
+use anyhow::Error;
 use dockworker::errors::*;
 use dockworker::{ContainerListOptions, Docker};
-use failure::Fail;
 
 fn find_all_exported_ports() -> Result<()> {
     let docker = Docker::connect_with_defaults()?;
@@ -25,7 +24,7 @@ fn find_all_exported_ports() -> Result<()> {
 fn main() {
     if let Err(err) = find_all_exported_ports() {
         eprint!("Error: ");
-        for e in Fail::iter_causes(&err) {
+        for e in Error::new(err).chain() {
             eprintln!("{}", e);
         }
     }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::result;
 use std::time::Duration;
 use url;
 
@@ -16,7 +15,7 @@ use container::{
 };
 
 pub use credentials::{Credential, UserPassword};
-use errors::*;
+use errors::{DockworkerError, Result};
 use filesystem::{FilesystemChange, XDockerContainerPathStat};
 use hyper_client::HyperClient;
 use image::{Image, ImageId, SummaryImage};
@@ -56,7 +55,7 @@ pub fn default_cert_path() -> Result<PathBuf> {
     if let Ok(ref path) = from_env {
         Ok(PathBuf::from(path))
     } else {
-        let home = dirs::home_dir().ok_or_else(|| ErrorKind::NoCertPath)?;
+        let home = dirs::home_dir().ok_or_else(|| DockworkerError::NoCertPath)?;
         Ok(home.join(".docker"))
     }
 }
@@ -106,7 +105,7 @@ impl ::std::error::Error for DockerError {
 }
 
 /// Deserialize from json string
-fn api_result<D: DeserializeOwned>(res: Response) -> result::Result<D, Error> {
+fn api_result<D: DeserializeOwned>(res: Response) -> Result<D> {
     if res.status.is_success() {
         Ok(serde_json::from_reader::<_, D>(res)?)
     } else {
@@ -115,7 +114,7 @@ fn api_result<D: DeserializeOwned>(res: Response) -> result::Result<D, Error> {
 }
 
 /// Expect 204 NoContent
-fn no_content(res: Response) -> result::Result<(), Error> {
+fn no_content(res: Response) -> Result<()> {
     if res.status == StatusCode::NO_CONTENT {
         Ok(())
     } else {
@@ -124,7 +123,7 @@ fn no_content(res: Response) -> result::Result<(), Error> {
 }
 
 /// Expect 204 NoContent or 304 NotModified
-fn no_content_or_not_modified(res: Response) -> result::Result<(), Error> {
+fn no_content_or_not_modified(res: Response) -> Result<()> {
     if res.status == StatusCode::NO_CONTENT || res.status == StatusCode::NOT_MODIFIED {
         Ok(())
     } else {
@@ -135,7 +134,7 @@ fn no_content_or_not_modified(res: Response) -> result::Result<(), Error> {
 /// Ignore succeed response
 ///
 /// Read whole response body, then ignore it.
-fn ignore_result(res: Response) -> result::Result<(), Error> {
+fn ignore_result(res: Response) -> Result<()> {
     if res.status.is_success() {
         res.bytes().last(); // ignore
         Ok(())
@@ -194,7 +193,7 @@ impl Docker {
                 Docker::connect_with_http(&host)
             }
         } else {
-            Err(ErrorKind::UnsupportedScheme { host: host.clone() }.into())
+            Err(DockworkerError::UnsupportedScheme { host: host.clone() }.into())
         }
     }
 
@@ -215,7 +214,7 @@ impl Docker {
 
     #[cfg(not(unix))]
     pub fn connect_with_unix(addr: &str) -> Result<Docker> {
-        Err(ErrorKind::UnsupportedScheme {
+        Err(DockworkerError::UnsupportedScheme {
             host: addr.to_owned(),
         }
         .into())
@@ -223,24 +222,28 @@ impl Docker {
 
     #[cfg(feature = "openssl")]
     pub fn connect_with_ssl(addr: &str, key: &Path, cert: &Path, ca: &Path) -> Result<Docker> {
-        let client = HyperClient::connect_with_ssl(addr, key, cert, ca).context(
-            ErrorKind::CouldNotConnect {
-                addr: addr.to_owned(),
-            },
-        )?;
+        let client = HyperClient::connect_with_ssl(addr, key, cert, ca).map_err(|err| {
+            DockworkerErr::CouldNotConnect {
+                addr: addr.to_string(),
+                source: err,
+            }
+        })?;
         Ok(Docker::new(client, Protocol::Tcp))
     }
 
     #[cfg(not(feature = "openssl"))]
     pub fn connect_with_ssl(_addr: &str, _key: &Path, _cert: &Path, _ca: &Path) -> Result<Docker> {
-        Err(ErrorKind::SslDisabled.into())
+        Err(DockworkerError::SslDisabled.into())
     }
 
     /// Connect using unsecured HTTP.  This is strongly discouraged
     /// everywhere but on Windows when npipe support is not available.
     pub fn connect_with_http(addr: &str) -> Result<Docker> {
-        let client = HyperClient::connect_with_http(addr).context(ErrorKind::CouldNotConnect {
-            addr: addr.to_owned(),
+        let client = HyperClient::connect_with_http(addr).map_err(|err| {
+            DockworkerError::CouldNotConnect {
+                addr: addr.to_string(),
+                source: err.into(),
+            }
         })?;
         Ok(Docker::new(client, Protocol::Tcp))
     }
@@ -730,9 +733,11 @@ impl Docker {
                     .get("X-Docker-Container-Path-Stat")
                     .map(|h| h.to_str().unwrap_or(""))
                     .unwrap_or("");
-                let bytes = base64::decode(stat_base64).context(ErrorKind::ParseError {
-                    input: String::from(stat_base64),
-                })?;
+                let bytes =
+                    base64::decode(stat_base64).map_err(|src| DockworkerError::ParseError {
+                        input: String::from(stat_base64),
+                        source: src,
+                    })?;
                 let path_stat: XDockerContainerPathStat = serde_json::from_slice(&bytes)?;
                 Ok(path_stat)
             })
@@ -994,13 +999,13 @@ impl Docker {
             // looking for file name like XXXXXXXXXXXXXX.json
             if path.extension() == Some(OsStr::new("json")) && path != Path::new("manifest.json") {
                 let stem = path.file_stem().unwrap(); // contains .json
-                let id = stem.to_str().ok_or(ErrorKind::Unknown {
+                let id = stem.to_str().ok_or(DockworkerError::Unknown {
                     message: format!("convert to String: {:?}", stem),
                 })?;
                 return Ok(ImageId::new(id.to_string()));
             }
         }
-        Err(ErrorKind::Unknown {
+        Err(DockworkerError::Unknown {
             message: "no expected file: XXXXXX.json".to_owned(),
         }
         .into())
@@ -1627,7 +1632,7 @@ mod tests {
             assert!(match docker.get_file(&container.id, test_file) {
                 Ok(_) => false,
                 Err(err) => {
-                    if let ErrorKind::Docker = err.kind() {
+                    if let DockworkerError::Docker = err.kind() {
                         true // not found
                     } else {
                         false

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1631,13 +1631,7 @@ mod tests {
 
             assert!(match docker.get_file(&container.id, test_file) {
                 Ok(_) => false,
-                Err(err) => {
-                    if let DockworkerError::Docker = err.kind() {
-                        true // not found
-                    } else {
-                        false
-                    }
-                }
+                Err(DockworkerError) => true,
             });
 
             docker

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::io;
 
-use anyhow;
 use base64;
 use docker;
 use http;
@@ -56,7 +55,10 @@ pub enum DockworkerError {
         source: http::uri::InvalidUri,
     },
     #[error("could not connect: {addr:?}")]
-    CouldNotConnect { addr: String, source: anyhow::Error },
+    CouldNotConnect {
+        addr: String,
+        source: Box<DockworkerError>,
+    },
     #[error("ssl error")]
     SSL,
     #[error("could not find DOCKER_CERT_PATH")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,169 +1,77 @@
 use std::env;
-use std::fmt;
 use std::io;
 
+use anyhow;
+use base64;
 use docker;
-pub use failure::ResultExt;
-use failure::{Backtrace, Context, Fail};
 use http;
 use hyper;
 #[cfg(feature = "openssl")]
 use openssl;
 use response;
+use thiserror;
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::std::result::Result<T, DockworkerError>;
 
-#[derive(Fail, Debug, Clone)]
-pub enum ErrorKind {
-    #[fail(display = "io error")]
-    Io,
-    #[fail(display = "envvar error")]
-    Envvar,
-    #[fail(display = "hyper error")]
-    Hyper,
-    #[fail(display = "json error")]
-    Json,
-    #[fail(display = "docker error")]
-    Docker,
-    #[fail(display = "response error")]
-    Response,
-    #[fail(display = "http error")]
-    Http,
-    #[fail(display = "invalid uri: {}", var)]
-    InvalidUri { var: String },
-    #[fail(display = "ssl error")]
+#[derive(thiserror::Error, Debug)]
+pub enum DockworkerError {
+    #[error("io error")]
+    Io {
+        #[from]
+        source: io::Error,
+    },
+    #[error("envvar error")]
+    Envvar {
+        #[from]
+        source: env::VarError,
+    },
+    #[error("hyper error")]
+    Hyper {
+        #[from]
+        source: hyper::Error,
+    },
+    #[error("json error")]
+    Json {
+        #[from]
+        source: ::serde_json::Error,
+    },
+    #[error("docker error")]
+    Docker {
+        #[from]
+        source: docker::DockerError,
+    },
+    #[error("response error")]
+    Response {
+        #[from]
+        source: response::Error,
+    },
+    #[error("http error")]
+    Http {
+        #[from]
+        source: http::Error,
+    },
+    #[error("invalid uri")]
+    InvalidUri {
+        #[from]
+        source: http::uri::InvalidUri,
+    },
+    #[error("could not connect: {addr:?}")]
+    CouldNotConnect { addr: String, source: anyhow::Error },
+    #[error("ssl error")]
     SSL,
-    #[fail(display = "could not connect: {}", addr)]
-    CouldNotConnect { addr: String },
-    #[fail(display = "could not find DOCKER_CERT_PATH")]
+    #[error("could not find DOCKER_CERT_PATH")]
     NoCertPath,
-    #[fail(display = "parse error: {}", input)]
-    ParseError { input: String },
-    #[fail(display = "ssl support was disabled at compile time")]
+    #[error("parse error: {input:?}")]
+    ParseError {
+        input: String,
+        source: base64::DecodeError,
+    },
+    #[error("ssl support was disabled at compile time")]
     SslDisabled,
-    #[fail(display = "unsupported scheme: {}", host)]
+    #[error("unsupported scheme: {host:?}")]
     UnsupportedScheme { host: String },
-    #[fail(display = "poison error: {}", message)]
+    #[error("poison error: {message:?}")]
     Poison { message: String },
-    #[fail(display = "unknown error: {}", message)]
+    #[error("unknown error: {message:?}")]
     Unknown { message: String },
-}
-
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&(dyn Fail + 'static)> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
-    }
-}
-
-impl Error {
-    pub fn new(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
-
-    pub fn kind(&self) -> &ErrorKind {
-        self.inner.get_context()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Io),
-        }
-    }
-}
-
-impl From<env::VarError> for Error {
-    fn from(error: env::VarError) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Envvar),
-        }
-    }
-}
-
-impl From<hyper::Error> for Error {
-    fn from(error: hyper::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Hyper),
-        }
-    }
-}
-
-impl From<::serde_json::Error> for Error {
-    fn from(error: ::serde_json::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Json),
-        }
-    }
-}
-
-impl From<docker::DockerError> for Error {
-    fn from(error: docker::DockerError) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Docker),
-        }
-    }
-}
-
-impl From<response::Error> for Error {
-    fn from(error: response::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Response),
-        }
-    }
-}
-
-impl From<http::Error> for Error {
-    fn from(error: http::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::Http),
-        }
-    }
-}
-
-#[cfg(feature = "openssl")]
-impl From<hyper_tls::Error> for Error {
-    fn from(error: hyper_tls::Error) -> Self {
-        Error {
-            inner: error.context(ErrorKind::SSL),
-        }
-    }
-}
-
-#[cfg(feature = "openssl")]
-impl From<openssl::error::ErrorStack> for Error {
-    fn from(error: openssl::error::ErrorStack) -> Self {
-        Error {
-            inner: error.context(ErrorKind::SSL),
-        }
-    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,7 +55,7 @@ pub struct Error {
 }
 
 impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&(dyn Fail + 'static)> {
         self.inner.cause()
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,10 +10,10 @@ use openssl;
 use response;
 use thiserror;
 
-pub type Result<T> = ::std::result::Result<T, DockworkerError>;
+pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
-pub enum DockworkerError {
+pub enum Error {
     #[error("io error")]
     Io {
         #[from]
@@ -55,10 +55,7 @@ pub enum DockworkerError {
         source: http::uri::InvalidUri,
     },
     #[error("could not connect: {addr:?}")]
-    CouldNotConnect {
-        addr: String,
-        source: Box<DockworkerError>,
-    },
+    CouldNotConnect { addr: String, source: Box<Error> },
     #[error("ssl error")]
     SSL,
     #[error("could not find DOCKER_CERT_PATH")]

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -168,15 +168,17 @@ fn with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
     body: Option<T>,
     future: hyper::client::ResponseFuture,
 ) -> Box<
-    hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
+    dyn hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
         + Send
         + 'static,
 > {
     if max_redirects == 0 {
         Box::new(future)
             as Box<
-                hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
-                    + Send
+                dyn hyper::rt::Future<
+                        Item = hyper::Response<hyper::Body>,
+                        Error = hyper::error::Error,
+                    > + Send
                     + 'static,
             >
     } else {
@@ -187,7 +189,7 @@ fn with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
             if !res.status().is_redirection() || res.headers().get("Location").is_none() {
                 Box::new(Ok(res).into_future())
                     as Box<
-                        hyper::rt::Future<
+                        dyn hyper::rt::Future<
                                 Item = hyper::Response<hyper::Body>,
                                 Error = hyper::error::Error,
                             > + Send
@@ -236,8 +238,10 @@ fn with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
             }
         }))
             as Box<
-                hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
-                    + Send
+                dyn hyper::rt::Future<
+                        Item = hyper::Response<hyper::Body>,
+                        Error = hyper::error::Error,
+                    > + Send
                     + 'static,
             >
     }
@@ -251,7 +255,7 @@ fn request_with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
     body: Option<T>,
 ) -> Result<
     Box<
-        hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
+        dyn hyper::rt::Future<Item = hyper::Response<hyper::Body>, Error = hyper::error::Error>
             + Send
             + 'static,
     >,

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -8,7 +8,7 @@ use hyper::rt::Stream;
 use hyper::Uri;
 pub use hyperx::header::{ContentType, Headers};
 
-use errors::{DockworkerError, Result};
+use errors::{Error, Result};
 use http_client::HttpClient;
 
 use std::io::Read;
@@ -332,7 +332,7 @@ impl HyperClient {
 }
 
 impl HttpClient for HyperClient {
-    type Err = DockworkerError;
+    type Err = Error;
 
     fn get(&self, headers: &Headers, path: &str) -> Result<Response> {
         let url = join_uri(&self.base, path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 // for the `error_chain` crate.
 #![recursion_limit = "1024"]
 
+extern crate anyhow;
 extern crate base64;
 extern crate byteorder;
 extern crate chrono;
-extern crate failure;
 extern crate futures;
 extern crate http;
 extern crate hyper;
@@ -15,6 +15,7 @@ extern crate hyper_tls;
 #[cfg(unix)]
 extern crate hyperlocal;
 extern crate hyperx;
+extern crate thiserror;
 #[macro_use]
 extern crate log;
 extern crate mime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 // for the `error_chain` crate.
 #![recursion_limit = "1024"]
 
-extern crate anyhow;
 extern crate base64;
 extern crate byteorder;
 extern crate chrono;

--- a/src/response.rs
+++ b/src/response.rs
@@ -69,7 +69,7 @@ impl StdError for Error {
         &self.error
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -6,7 +6,7 @@ mod unix {
     pub use self::NixSignal::*;
     use nix::sys::signal::{Signal as NixSignal, SignalIterator as NixSignalIterator};
 
-    use crate::errors::Error;
+    use crate::errors::Result;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Signal(NixSignal);
@@ -23,7 +23,7 @@ mod unix {
             SignalIterator(NixSignal::iterator())
         }
 
-        pub fn from_c_int(signum: c_int) -> Result<Self, Error> {
+        pub fn from_c_int(signum: c_int) -> Result<Self> {
             Ok(NixSignal::from_c_int(signum)
                 .map_err(|err| io::Error::from_raw_os_error(err.as_errno().unwrap() as i32))?
                 .into())
@@ -71,7 +71,7 @@ mod windows {
             SignalIterator(vec![SIGKILL, SIGTERM].into_iter())
         }
 
-        pub fn from_c_int(signum: c_int) -> Result<Self, Error> {
+        pub fn from_c_int(signum: c_int) -> Result<Self, DockworkerError> {
             match signum {
                 9 => Ok(Signal::SIGKILL),
                 15 => Ok(Signal::SIGTERM),

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -49,7 +49,7 @@ mod windows {
     use std::io;
     use std::os::raw::c_int;
 
-    use crate::errors::Error;
+    use crate::errors::Result;
 
     #[repr(i32)]
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
@@ -71,7 +71,7 @@ mod windows {
             SignalIterator(vec![SIGKILL, SIGTERM].into_iter())
         }
 
-        pub fn from_c_int(signum: c_int) -> Result<Self, DockworkerError> {
+        pub fn from_c_int(signum: c_int) -> Result<Self> {
             match signum {
                 9 => Ok(Signal::SIGKILL),
                 15 => Ok(Signal::SIGTERM),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -3,7 +3,7 @@ use std::iter;
 
 use serde_json;
 
-use errors::*;
+use errors::Result;
 
 use hyper_client::Response;
 
@@ -28,11 +28,7 @@ impl iter::Iterator for StatsReader {
         let mut line = String::new();
         match self.buf.read_line(&mut line) {
             Ok(0) => None,
-            Ok(_) => Some(
-                serde_json::from_str::<Stats>(&line)
-                    .context(ErrorKind::ParseError { input: line })
-                    .map_err(Into::into),
-            ),
+            Ok(_) => Some(serde_json::from_str::<Stats>(&line).map_err(Into::into)),
             Err(err) => Some(Err(err.into())),
         }
     }


### PR DESCRIPTION
Addresses https://github.com/eldesh/dockworker/issues/75
Builds on https://github.com/eldesh/dockworker/pull/95 (because the compiler warnings were annoying me)

While this is largely a cleanup PR it does make a couple significant changes:

* Renames `ErrorKind` -> `DockworkerError` (I have no problem with changing this back, I just thought it was better to be more descriptive for the sake of external uses that might import it)
* Removes the `var` field from `Dockworker::InvalidUri` since uri parsing is only done during creation of `HyperClient` connections whose errors are ultimately wrapped in `Dockworker::CouldNotConnect` which already includes the same information.