### PR TITLE
Update: transfer to idein organization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
 version = "0.0.20"
-authors = ["eldesh <nephits@gmail.com>"]
+authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
-homepage = "https://github.com/eldesh/dockworker"
-repository = "https://github.com/eldesh/dockworker"
+homepage = "https://github.com/Idein/dockworker"
+repository = "https://github.com/Idein/dockworker"
 documentation = "https://docs.rs/dockworker"
 readme = "README.md"
 keywords = ["docker"]
@@ -13,7 +13,7 @@ edition = "2018"
 
 [badges]
 appveyor = { repository = "eldesh/dockworker", branch = "master", service = "github" }
-circle-ci = { repository = "eldesh/dockworker" }
+circle-ci = { repository = "Idein/dockworker" }
 maintenance = { status = "actively-developed" }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dockworker: Rust library for talking to the Docker daemon
 
-[![CircleCI](https://circleci.com/gh/eldesh/dockworker/tree/master.svg?style=svg)](https://circleci.com/gh/eldesh/dockworker/tree/master)
+[![CircleCI](https://circleci.com/gh/Idein/dockworker/tree/master.svg?style=svg)](https://circleci.com/gh/Idein/dockworker/tree/master)
 [![Build status](https://ci.appveyor.com/api/projects/status/88ut6hplkw7vtjy4/branch/master?svg=true)](https://ci.appveyor.com/project/eldesh/dockworker)
 
 ## Support

--- a/src/container.rs
+++ b/src/container.rs
@@ -690,7 +690,7 @@ where
 mod test {
     use super::*;
 
-    // https://github.com/eldesh/dockworker/issues/84
+    // https://github.com/idein/dockworker/issues/84
     #[test]
     fn serde_network() {
         let network_settings_str = r#"{


### PR DESCRIPTION
This repository has been transferred from `eldesh/dockworker` to `Idein/dockworker`.
Update links to Idein/*.