### PR TITLE
bump up 0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "backtrace-sys",
  "base64 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.20"
+version = "0.0.21"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
 homepage = "https://github.com/Idein/dockworker"


### PR DESCRIPTION
`release 0.0.21`
(Since release 0.0.20 was skipped, this changelog also contains the differences.)

## New features
- RestartPolicy constructors (#104)
- Workaround for hyper deadlock (#102)

## Changes
- This repository is transferred to Idein/dockworker (#106)

## Bug fixes
- Fix hyper workaround test (#107)
