### PR TITLE
Integrate container test

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -11,7 +11,7 @@ use std::io::{self, Read};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[allow(non_snake_case)]
 pub struct Container {
     pub Id: String,
@@ -47,13 +47,13 @@ pub enum PortType {
     Udp,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_snake_case)]
 pub struct HostConfig {
     pub NetworkMode: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[allow(non_snake_case)]
 pub struct SummaryNetworkSettings {
     pub Networks: Option<HashMap<String, Option<Network>>>,
@@ -145,7 +145,7 @@ pub struct Config {
     pub WorkingDir: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_snake_case)]
 pub struct Mount {
     // Name (optional)

--- a/src/container.rs
+++ b/src/container.rs
@@ -200,7 +200,8 @@ pub struct LogMessage {
     pub Output: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq, PartialOrd, Eq, Ord)]
+#[serde(rename_all = "lowercase")]
 pub enum HealthState {
     /// Indicates there is no healthcheck
     NoHealthcheck,

--- a/src/container.rs
+++ b/src/container.rs
@@ -291,7 +291,7 @@ impl std::fmt::Display for ContainerInfo {
     }
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ContainerStatus {
     Created,
@@ -303,7 +303,7 @@ pub enum ContainerStatus {
     Dead,
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Serialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Serialize)]
 pub struct ContainerFilters {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     id: Vec<String>,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -968,7 +968,7 @@ impl Docker {
             .and_then(api_result)
             .map(|mut hs: Vec<ImageLayer>| {
                 hs.iter_mut().for_each(|change| {
-                    if change.id == Some("<missing>".into()) {
+                    if change.id.as_deref() == Some("<missing>") {
                         change.id = None;
                     }
                 });

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1544,9 +1544,7 @@ mod tests {
     fn test_container(docker: &Docker, image: &str) {
         println!("stop container");
         {
-            let mut create = ContainerCreateOptions::new(image);
-            let host_config = ContainerHostConfig::new();
-            create.host_config(host_config);
+            let create = ContainerCreateOptions::new(image);
 
             let container = docker
                 .create_container(Some("dockworker_test_0"), &create)
@@ -1609,8 +1607,7 @@ mod tests {
         }
         println!("stats container");
         {
-            let mut create = ContainerCreateOptions::new(image);
-            create.host_config(ContainerHostConfig::new());
+            let create = ContainerCreateOptions::new(image);
 
             let container = docker
                 .create_container(Some("dockworker_test_3"), &create)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1725,9 +1725,9 @@ mod tests {
             let container = docker
                 .create_container(Some("dockworker_checkpoint_test"), &create)
                 .unwrap();
-            assert!(docker.start_container(&container.id).is_ok());
+            docker.start_container(&container.id)..unwrap();
 
-            assert!(docker
+            docker
                 .checkpoint_container(
                     &container.id,
                     &CheckpointCreateOptions {
@@ -1736,7 +1736,7 @@ mod tests {
                         exit: Some(true),
                     },
                 )
-                .is_ok());
+                .unwrap();
 
             assert_eq!(
                 "v1".to_string(),
@@ -1748,27 +1748,27 @@ mod tests {
 
             thread::sleep(Duration::from_secs(1));
 
-            assert!(docker
+            docker
                 .resume_container_from_checkpoint(&container.id, "v1", None)
-                .is_ok());
+                .unwrap();
 
-            assert!(docker
+            docker
                 .stop_container(&container.id, Duration::new(0, 0))
-                .is_ok());
+                .unwrap();
 
-            assert!(docker
+            docker
                 .delete_checkpoint(
                     &container.id,
                     &CheckpointDeleteOptions {
                         checkpoint_id: "v1".to_string(),
-                        checkpoint_dir: None
-                    }
+                        checkpoint_dir: None,
+                    },
                 )
-                .is_ok());
+                .unwrap();
 
-            assert!(docker
+            docker
                 .remove_container("dockworker_checkpoint_test", None, None, None)
-                .is_ok());
+                .unwrap();
         })
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1755,7 +1755,7 @@ mod tests {
             let container = docker
                 .create_container(Some("dockworker_checkpoint_test"), &create)
                 .unwrap();
-            docker.start_container(&container.id)..unwrap();
+            docker.start_container(&container.id).unwrap();
 
             docker
                 .checkpoint_container(
@@ -1955,7 +1955,9 @@ mod tests {
             .host_config(host_config)
             .env("WAIT_BEFORE_CONTINUING=YES".to_string());
 
-        let container = docker.create_container(None, &create).unwrap();
+        let container = docker
+            .create_container(Some("attach_container_test"), &create)
+            .unwrap();
         docker.start_container(&container.id).unwrap();
         let res = docker
             .attach_container(&container.id, None, true, true, false, true, true)
@@ -2005,7 +2007,9 @@ mod tests {
             .cmd("10".to_owned())
             .host_config(host_config);
 
-        let container = docker.create_container(None, &create).unwrap();
+        let container = docker
+            .create_container(Some("exec_container_test"), &create)
+            .unwrap();
         docker.start_container(&container.id).unwrap();
 
         let mut exec_config = CreateExecOptions::new();
@@ -2057,7 +2061,9 @@ mod tests {
         let mut create = ContainerCreateOptions::new(image_name);
         create.host_config(host_config);
 
-        let container = docker.create_container(None, &create).unwrap();
+        let container = docker
+            .create_container(Some("signal_container_test"), &create)
+            .unwrap();
         docker.start_container(&container.id).unwrap();
         let res = docker
             .attach_container(&container.id, None, true, true, false, true, true)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1376,6 +1376,7 @@ mod tests {
             "container info: {:?}",
             docker.container_info(&container).unwrap()
         );
+        docker.start_container(&container).unwrap();
         docker
             .stop_container(container, Duration::from_secs(10))
             .unwrap();
@@ -1385,6 +1386,7 @@ mod tests {
     }
 
     fn restart_container(docker: &Docker, container: &str) {
+        docker.start_container(&container).unwrap();
         docker
             .stop_container(container, Duration::from_secs(10))
             .unwrap();

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1384,6 +1384,18 @@ mod tests {
             .unwrap();
     }
 
+    fn restart_container(docker: &Docker, container: &str) {
+        docker
+            .stop_container(container, Duration::from_secs(10))
+            .unwrap();
+        docker
+            .restart_container(container, Duration::from_secs(10))
+            .unwrap();
+        docker
+            .stop_container(container, Duration::from_secs(10))
+            .unwrap();
+    }
+
     fn stop_wait_container(docker: &Docker, container: &str) {
         docker.start_container(container).unwrap();
         docker.wait_container(container).unwrap();
@@ -1541,6 +1553,20 @@ mod tests {
                 .unwrap();
 
             double_stop_container(&docker, &container.id);
+
+            docker
+                .remove_container(&container.id, None, None, None)
+                .unwrap();
+        }
+        println!("restart container");
+        {
+            let create = ContainerCreateOptions::new(image);
+
+            let container = docker
+                .create_container(Some("dockworker_test_0"), &create)
+                .unwrap();
+
+            restart_container(&docker, &container.id);
 
             docker
                 .remove_container(&container.id, None, None, None)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1676,7 +1676,14 @@ mod tests {
     }
 
     fn test_image_api(docker: &Docker, name: &str, tag: &str) {
+        let containers_pre = docker
+            .list_containers(Some(true), None, Some(true), ContainerFilters::new())
+            .unwrap();
         test_container(&docker, &format!("{}:{}", name, tag));
+        let containers_post = docker
+            .list_containers(Some(true), None, Some(true), ContainerFilters::new())
+            .unwrap();
+        assert_eq!(containers_pre, containers_post);
     }
 
     fn test_image(docker: &Docker, name: &str, tag: &str) {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -3,6 +3,7 @@ use crate::container::{
 };
 pub use crate::credentials::{Credential, UserPassword};
 use crate::errors::*;
+use crate::event::EventResponse;
 use crate::filesystem::{FilesystemChange, XDockerContainerPathStat};
 use crate::http_client::{HaveHttpClient, HttpClient};
 use crate::hyper_client::{HyperClient, Response};

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1542,13 +1542,20 @@ mod tests {
     }
 
     fn test_container(docker: &Docker, image: &str) {
+        let mut next_id = {
+            let mut id = 0;
+            move || {
+                let next = format!("test_container_{}", id);
+                id = id + 1;
+                next
+            }
+        };
+
         println!("stop container");
         {
             let create = ContainerCreateOptions::new(image);
 
-            let container = docker
-                .create_container(Some("dockworker_test_0"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             double_stop_container(&docker, &container.id);
 
@@ -1560,9 +1567,7 @@ mod tests {
         {
             let create = ContainerCreateOptions::new(image);
 
-            let container = docker
-                .create_container(Some("dockworker_test_0"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             restart_container(&docker, &container.id);
 
@@ -1577,9 +1582,7 @@ mod tests {
             host_config.auto_remove(true);
             create.host_config(host_config);
 
-            let container = docker
-                .create_container(Some("dockworker_test_1"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             stop_wait_container(&docker, &container.id);
 
@@ -1595,9 +1598,7 @@ mod tests {
         {
             let create = ContainerCreateOptions::new(image);
 
-            let container = docker
-                .create_container(Some("dockworker_test_2"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             head_file_container(&docker, &container.id);
 
@@ -1609,9 +1610,7 @@ mod tests {
         {
             let create = ContainerCreateOptions::new(image);
 
-            let container = docker
-                .create_container(Some("dockworker_test_3"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             stats_container(&docker, &container.id);
 
@@ -1624,9 +1623,7 @@ mod tests {
             let mut create = ContainerCreateOptions::new(image);
             create.cmd("ls".to_string());
 
-            let container = docker
-                .create_container(Some("dockworker_test_4"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             wait_container(&docker, &container.id);
 
@@ -1638,9 +1635,7 @@ mod tests {
         {
             let create = ContainerCreateOptions::new(image);
 
-            let container = docker
-                .create_container(Some("dockworker_test_5"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             put_file_container(&docker, &container.id);
 
@@ -1654,9 +1649,7 @@ mod tests {
             create.entrypoint(vec!["cat".into()]);
             create.cmd("/etc/motd".to_string());
 
-            let container = docker
-                .create_container(Some("dockworker_test_6"), &create)
-                .unwrap();
+            let container = docker.create_container(Some(&next_id()), &create).unwrap();
 
             log_container(&docker, &container.id);
 
@@ -1684,11 +1677,12 @@ mod tests {
                 endpoints_config: config.into(),
             });
 
+            let container_name = next_id();
             let container = docker
-                .create_container(Some("dockworker_test_7"), &create)
+                .create_container(Some(&container_name), &create)
                 .unwrap();
 
-            connect_container(&docker, "dockworker_test_7", &container.id, &network.Id);
+            connect_container(&docker, &container_name, &container.id, &network.Id);
 
             docker
                 .remove_container(&container.id, None, None, None)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1550,7 +1550,6 @@ mod tests {
                 next
             }
         };
-
         println!("stop container");
         {
             let create = ContainerCreateOptions::new(image);
@@ -1693,14 +1692,21 @@ mod tests {
     }
 
     fn test_image_api(docker: &Docker, name: &str, tag: &str) {
-        let containers_pre = docker
-            .list_containers(Some(true), None, Some(true), ContainerFilters::new())
-            .unwrap();
+        let mut filter = ContainerFilters::new();
+        filter.name("test_container_");
+
+        assert!(
+            docker
+                .list_containers(Some(true), None, Some(true), filter.clone())
+                .unwrap()
+                .is_empty(),
+            "remove containers 'test_container_*'"
+        );
         test_container(&docker, &format!("{}:{}", name, tag));
-        let containers_post = docker
-            .list_containers(Some(true), None, Some(true), ContainerFilters::new())
-            .unwrap();
-        assert_eq!(containers_pre, containers_post);
+        assert!(docker
+            .list_containers(Some(true), None, Some(true), filter)
+            .unwrap()
+            .is_empty());
     }
 
     fn test_image(docker: &Docker, name: &str, tag: &str) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(non_snake_case)]
+pub struct EventActor {
+    pub ID: String,
+    pub Attributes: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(non_snake_case)]
+pub struct EventResponse {
+    pub Type: String,
+    pub Action: String,
+    pub Actor: EventActor,
+    pub time: u64,
+    pub timeNano: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod container;
 pub mod credentials;
 mod docker;
 pub mod errors;
+pub mod event;
 pub mod filesystem;
 mod http_client;
 mod hyper_client;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1034,16 +1034,6 @@ pub struct ImageLayer {
     pub comment: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[allow(non_snake_case)]
-pub struct EventResponse {
-    pub Type: String,
-    pub Action: String,
-    pub Actor: EventActor,
-    pub time: u64,
-    pub timeNano: u64,
-}
-
 #[derive(Debug, PartialEq, PartialOrd, Serialize)]
 pub struct EventFilters {
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -1075,13 +1065,6 @@ pub struct EventFilters {
     type_: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     volume: Vec<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[allow(non_snake_case)]
-pub struct EventActor {
-    pub ID: String,
-    pub Attributes: HashMap<String, String>,
 }
 
 impl Default for EventFilters {


### PR DESCRIPTION
close #70

- Performs unit tests sequentially
- Add some container api calls to the test

This change lead to:

- Reduces dependency on various versions of the alpine image
    - before: `alpine: 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and latest`
    - after: `alpine: 3.9 and 3.10`
