### PR TITLE
bump up 0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "backtrace-sys",
  "base64 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.22"
+version = "0.0.23"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
 homepage = "https://github.com/Idein/dockworker"


### PR DESCRIPTION
`release 0.0.23`

## Improvements

- Remove dependency on hyperx (#116)
