### PR TITLE
Fix deserialization if `GET /network` response contains `AuxiliaryAddresses`

### DIFF
--- a/src/fixtures/list_networks.json
+++ b/src/fixtures/list_networks.json
@@ -110,5 +110,48 @@
       "com.docker.compose.network": "default",
       "com.docker.compose.project": "test"
     }
+  },
+  {
+    "Name": "test_macvlan",
+    "Id": "032c6988efef37feb7f7c807fc66e13708bec7325bff4eed90a38815c0d1501f",
+    "Created": "2020-12-10T12:00:07.472567245-04:00",
+    "Scope": "local",
+    "Driver": "macvlan",
+    "EnableIPv6": false,
+    "IPAM": {
+        "Driver": "default",
+        "Options": {},
+        "Config": [
+            {
+                "Subnet": "172.16.0.0/16",
+                "IPRange": "172.16.64.0/24",
+                "Gateway": "172.16.0.1",
+                "AuxiliaryAddresses": {
+                  "host": "172.16.64.0",
+                  "test_device": "172.16.64.1"
+                }
+            }
+        ]
+    },
+    "Internal": false,
+    "Attachable": false,
+    "Ingress": false,
+    "ConfigFrom": {
+        "Network": ""
+    },
+    "ConfigOnly": false,
+    "Containers": {
+        "042116c93520a9e1cd37999db08691a3ab343ac95947b3518d38293f026fc7cb": {
+            "Name": "macvlan_container",
+            "EndpointID": "8a54b40ee98d6918b26c5fdeecb3cc748f89782f0e7e3dc2f4b0ec990b5b0319",
+            "MacAddress": "02:42:ac:1b:27:6f",
+            "IPv4Address": "172.16.64.100/16",
+            "IPv6Address": ""
+        }
+    },
+    "Options": {
+        "parent": "eno1"
+    },
+    "Labels": {}
   }
 ]

--- a/src/network.rs
+++ b/src/network.rs
@@ -27,7 +27,7 @@ pub struct Network {
 #[allow(non_snake_case)]
 pub struct IPAM {
     pub Driver: String,
-    pub Config: Vec<HashMap<String, String>>,
+    pub Config: Vec<IPAMConfig>,
     #[serde(deserialize_with = "format::null_to_default")]
     pub Options: HashMap<String, String>,
 }
@@ -40,6 +40,23 @@ impl Default for IPAM {
             Options: HashMap::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[allow(non_snake_case)]
+pub struct IPAMConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Subnet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub IPRange: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Gateway: Option<String>,
+    #[serde(
+        skip_serializing_if = "HashMap::is_empty",
+        deserialize_with = "format::null_to_default",
+        default
+    )]
+    pub AuxiliaryAddresses: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]


### PR DESCRIPTION
Dockworker fails to parse `GET /network` response if it contains `AuxiliaryAddresses`. This happens because the value of `AuxiliaryAddresses` is a structure, so it can't be deserialized to `HashMap<String, String>`.  Unfortunately, this property is not well documented in Docker's API documentation, but is used for `macvlan` type networks (https://docs.docker.com/network/macvlan/).

This PR contains 2 commits:
- `25a4a70`: Add test to demonstrate failure condition
- `29788ed`: Fix by replacing `HashMap<String, String>` with new struct `IPAMConfig`

Note that this would break existing code using `IPAM.Config`

