### PR TITLE
bump up 0.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
 homepage = "https://github.com/Idein/dockworker"


### PR DESCRIPTION
# Improvements

- Update dependencies #112
    - Update tokio and hyper
    - Replace failure crate with thiserror
- Extend IPAMConfig to accept AuxiliaryAddresses for macvlan network
- Restructuring unit tests
    - Reduced number of images used for testing
    - Add test cases

