### PR TITLE
bump up 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
 homepage = "https://github.com/Idein/dockworker"


### PR DESCRIPTION
Bump up the version to `0.1.1` which complies with semver conventions.

# Improvements

- Properly handle errors that occur while reading hyper's Response body. #136