### PR TITLE
return the stream of build log in build api

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -30,15 +30,22 @@ pub trait HttpClient {
         body: &str,
     ) -> Result<Response<hyper::Body>, Self::Err>;
 
-    async fn delete(&self, headers: &HeaderMap, path: &str)
-        -> Result<Response<Vec<u8>>, Self::Err>;
-
     async fn post_file(
         &self,
         headers: &HeaderMap,
         path: &str,
         file: &Path,
     ) -> Result<Response<Vec<u8>>, Self::Err>;
+
+    async fn post_file_stream(
+        &self,
+        headers: &HeaderMap,
+        path: &str,
+        file: &Path,
+    ) -> Result<Response<hyper::Body>, Self::Err>;
+
+    async fn delete(&self, headers: &HeaderMap, path: &str)
+        -> Result<Response<Vec<u8>>, Self::Err>;
 
     async fn put_file(
         &self,

--- a/src/response.rs
+++ b/src/response.rs
@@ -26,10 +26,31 @@ pub struct Progress {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
+pub struct Stream {
+    pub stream: String,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
 pub struct Status {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub status: String,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct LogID {
+    pub ID: String,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
+pub struct Aux {
+    pub aux: LogID,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
+pub struct LogResponse {
+    pub response: String,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Serialize, Deserialize)]
@@ -53,6 +74,9 @@ pub struct Error {
 pub enum Response {
     Progress(Progress),
     Status(Status),
+    Stream(Stream),
+    Aux(Aux),
+    Response(LogResponse),
     Error(Error),
     /// unknown response
     Unknown(json::Value),


### PR DESCRIPTION
Return the response stream of `build_image`. The response used to be returned in old versions, but changed in https://github.com/Idein/dockworker/pull/137, which I think is a mistake. This patch restores the response. Though this patch adds a few new types of response, `build_image` mostly uses `{"stream": "log messages"}` format.


This is a **breaking change** and you should bump the minor version on releasing.

