### PR TITLE
bump up 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 license = "Apache-2.0"
 homepage = "https://github.com/Idein/dockworker"
@@ -44,7 +44,17 @@ serde_json = "1"
 url = "2"
 byteorder = "1"
 tar = "0.4"
-tokio = { version = "1", features = ["time", "fs", "net", "io-util", "io-std", "test-util", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1", features = [
+    "time",
+    "fs",
+    "net",
+    "io-util",
+    "io-std",
+    "test-util",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
 log = "0.4"
@@ -63,4 +73,3 @@ hyperlocal = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.4"
-


### PR DESCRIPTION
Bump up the version to `0.5.1`.

# New Features
- support docker 26.0.0 https://github.com/Idein/dockworker/pull/156