### PR TITLE
fix containers/{id}/stats

### DIFF
--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -8,10 +8,7 @@ async fn main() {
         .await
         .unwrap();
     for container in containers {
-        let mut stats = docker
-            .stats(&container.Id, Some(false), Some(true))
-            .await
-            .unwrap();
+        let mut stats = docker.stats(&container.Id, true).await.unwrap();
         use futures::stream::StreamExt;
         while let Some(stats) = stats.next().await {
             println!("{:#?}", stats.unwrap());


### PR DESCRIPTION
After some test i found that 

> curl --unix-socket /var/run/docker.sock http:/v1.24/containers/ad31ebf6f8b1c13e9fd725eaefc53225defe5bc7cd4dffdff486dc5be673a64f/stats\?stream

disable stream and enable one-shot and that 

> curl --unix-socket /var/run/docker.sock http:/v1.24/containers/ad31ebf6f8b1c13e9fd725eaefc53225defe5bc7cd4dffdff486dc5be673a64f/stats\?one-shot

do the opposite, so I fixed the endpoint





