### PR TITLE
Fixed Send + Sync issue with the list_containers function when called by tokio::task::spawn

### DIFF
--- a/examples/containers.rs
+++ b/examples/containers.rs
@@ -1,15 +1,18 @@
 use dockworker::{container::ContainerFilters, Docker};
+use tokio::task;
 
 #[tokio::main]
 async fn main() {
-    let docker = Docker::connect_with_defaults().unwrap();
-    let filter = ContainerFilters::new();
-    let containers = docker
-        .list_containers(None, None, None, filter)
-        .await
-        .unwrap();
+    task::spawn(async {
+        let docker = Docker::connect_with_defaults().unwrap();
+        let filter = ContainerFilters::new();
+        let containers = docker
+            .list_containers(None, None, None, filter)
+            .await
+            .unwrap();
 
-    containers.iter().for_each(|c| {
-        println!("{c:?}");
-    });
+        containers.iter().for_each(|c| {
+            println!("{c:?}");
+        });
+    });    
 }

--- a/examples/containers.rs
+++ b/examples/containers.rs
@@ -1,18 +1,15 @@
 use dockworker::{container::ContainerFilters, Docker};
-use tokio::task;
 
 #[tokio::main]
 async fn main() {
-    task::spawn(async {
-        let docker = Docker::connect_with_defaults().unwrap();
-        let filter = ContainerFilters::new();
-        let containers = docker
-            .list_containers(None, None, None, filter)
-            .await
-            .unwrap();
+    let docker = Docker::connect_with_defaults().unwrap();
+    let filter = ContainerFilters::new();
+    let containers = docker
+        .list_containers(None, None, None, filter)
+        .await
+        .unwrap();
 
-        containers.iter().for_each(|c| {
-            println!("{c:?}");
-        });
+    containers.iter().for_each(|c| {
+        println!("{c:?}");
     });
 }

--- a/examples/containers.rs
+++ b/examples/containers.rs
@@ -14,5 +14,5 @@ async fn main() {
         containers.iter().for_each(|c| {
             println!("{c:?}");
         });
-    });    
+    });
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -927,6 +927,7 @@ impl Docker {
             let mut param = url::form_urlencoded::Serializer::new(String::new());
             param.append_pair("path", &dst.to_string_lossy());
             param.append_pair("noOverwriteDirNonDir", &noOverwriteDirNonDir.to_string());
+            param.finish()
         };
         let res = self
             .http_client()

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -343,14 +343,8 @@ impl Docker {
         };
 
         let path = prepare_path();
-        
-        let res = self
-            .http_client()
-            .get(
-                self.headers(),
-                &path,
-            )
-            .await?;
+
+        let res = self.http_client().get(self.headers(), &path).await?;
         api_result(res).map_err(Into::into)
     }
 


### PR DESCRIPTION
fixes #159 

The example change probably won't need to get merged in. Just wanted to show some context that caused compilation failures in some contexts