### PR TITLE
Add Docker API wrapper for /containers/prune endpoint

### DIFF
--- a/examples/prune-containers.rs
+++ b/examples/prune-containers.rs
@@ -14,14 +14,14 @@ async fn main() {
     // Prune containers with label filter
     let mut filters = ContainerPruneFilters::new();
     filters.label("test=example".to_string());
-    
+
     let result = docker.prune_containers(filters).await.unwrap();
     println!("Prune result (with label filter): {result:?}");
 
     // Prune containers older than 24 hours
     let mut filters = ContainerPruneFilters::new();
     filters.until("24h".to_string());
-    
+
     let result = docker.prune_containers(filters).await.unwrap();
     println!("Prune result (until 24h): {result:?}");
 }

--- a/examples/prune-containers.rs
+++ b/examples/prune-containers.rs
@@ -1,0 +1,27 @@
+use dockworker::{ContainerPruneFilters, Docker};
+
+#[tokio::main]
+async fn main() {
+    let docker = Docker::connect_with_defaults().unwrap();
+
+    // Prune all stopped containers without filters
+    let result = docker
+        .prune_containers(ContainerPruneFilters::new())
+        .await
+        .unwrap();
+    println!("Prune result (no filters): {result:?}");
+
+    // Prune containers with label filter
+    let mut filters = ContainerPruneFilters::new();
+    filters.label("test=example".to_string());
+    
+    let result = docker.prune_containers(filters).await.unwrap();
+    println!("Prune result (with label filter): {result:?}");
+
+    // Prune containers older than 24 hours
+    let mut filters = ContainerPruneFilters::new();
+    filters.until("24h".to_string());
+    
+    let result = docker.prune_containers(filters).await.unwrap();
+    println!("Prune result (until 24h): {result:?}");
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2304,7 +2304,7 @@ mod tests {
         let mut containers_to_cleanup = Vec::new();
 
         for i in 1..=4 {
-            let mut create_opts = ContainerCreateOptions::new("alpine:latest");
+            let mut create_opts = ContainerCreateOptions::new("alpine:3.9");
             create_opts
                 .label("test".to_string(), format!("container-{}", i))
                 .label("prune-test".to_string(), "true".to_string());

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2335,7 +2335,7 @@ mod tests {
         // Create more containers for label filtering tests
         let mut more_containers = Vec::new();
         for i in 5..=7 {
-            let mut create_opts = ContainerCreateOptions::new("alpine:latest");
+            let mut create_opts = ContainerCreateOptions::new("test-iostream:latest");
             create_opts
                 .label("test".to_string(), format!("container-{}", i))
                 .label(

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2302,25 +2302,22 @@ mod tests {
 
         // Create test containers with labels
         let mut containers_to_cleanup = Vec::new();
-        
+
         for i in 1..=4 {
             let mut create_opts = ContainerCreateOptions::new("alpine:latest");
             create_opts
                 .label("test".to_string(), format!("container-{}", i))
                 .label("prune-test".to_string(), "true".to_string());
-            
+
             if i % 2 == 0 {
                 create_opts.label("keep".to_string(), "false".to_string());
             } else {
                 create_opts.label("keep".to_string(), "true".to_string());
             }
-            
-            let container = docker
-                .create_container(None, &create_opts)
-                .await
-                .unwrap();
+
+            let container = docker.create_container(None, &create_opts).await.unwrap();
             containers_to_cleanup.push(container.id.clone());
-            
+
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
 
@@ -2341,12 +2338,16 @@ mod tests {
             let mut create_opts = ContainerCreateOptions::new("alpine:latest");
             create_opts
                 .label("test".to_string(), format!("container-{}", i))
-                .label("environment".to_string(), if i == 6 { "production".to_string() } else { "development".to_string() });
-            
-            let container = docker
-                .create_container(None, &create_opts)
-                .await
-                .unwrap();
+                .label(
+                    "environment".to_string(),
+                    if i == 6 {
+                        "production".to_string()
+                    } else {
+                        "development".to_string()
+                    },
+                );
+
+            let container = docker.create_container(None, &create_opts).await.unwrap();
             more_containers.push(container.id.clone());
         }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2304,7 +2304,7 @@ mod tests {
         let mut containers_to_cleanup = Vec::new();
 
         for i in 1..=4 {
-            let mut create_opts = ContainerCreateOptions::new("alpine:3.9");
+            let mut create_opts = ContainerCreateOptions::new("test-iostream:latest");
             create_opts
                 .label("test".to_string(), format!("container-{}", i))
                 .label("prune-test".to_string(), "true".to_string());

--- a/src/options.rs
+++ b/src/options.rs
@@ -1364,14 +1364,14 @@ impl Serialize for ContainerPruneFilters {
     {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(None)?;
-        
+
         if !self.until.is_empty() {
             map.serialize_entry("until", &self.until)?;
         }
         if !self.label.is_empty() {
             map.serialize_entry("label", &self.label)?;
         }
-        
+
         map.end()
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1330,6 +1330,61 @@ pub struct PrunedImages {
     SpaceReclaimed: i64,
 }
 
+/// Container prune filters
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ContainerPruneFilters {
+    pub until: Vec<String>,
+    pub label: Vec<String>,
+}
+
+impl ContainerPruneFilters {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.until.is_empty() && self.label.is_empty()
+    }
+
+    pub fn until(&mut self, until: String) -> &mut Self {
+        self.until.push(until);
+        self
+    }
+
+    pub fn label(&mut self, label: String) -> &mut Self {
+        self.label.push(label);
+        self
+    }
+}
+
+impl Serialize for ContainerPruneFilters {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        
+        if !self.until.is_empty() {
+            map.serialize_entry("until", &self.until)?;
+        }
+        if !self.label.is_empty() {
+            map.serialize_entry("label", &self.label)?;
+        }
+        
+        map.end()
+    }
+}
+
+/// Response of the prune containers api
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PrunedContainers {
+    #[serde(deserialize_with = "null_to_default")]
+    pub containers_deleted: Vec<String>,
+    pub space_reclaimed: i64,
+}
+
 /// Response of the history image api
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/src/test.rs
+++ b/src/test.rs
@@ -174,7 +174,7 @@ fn container_prune_filters_until() {
     let mut filters = ContainerPruneFilters::new();
     filters.until("24h".to_string());
     filters.until("1h".to_string());
-    
+
     assert!(!filters.is_empty());
     assert_eq!(filters.until, vec!["24h", "1h"]);
     assert!(filters.label.is_empty());
@@ -186,7 +186,7 @@ fn container_prune_filters_label() {
     let mut filters = ContainerPruneFilters::new();
     filters.label("test=example".to_string());
     filters.label("version=1.0".to_string());
-    
+
     assert!(!filters.is_empty());
     assert_eq!(filters.label, vec!["test=example", "version=1.0"]);
     assert!(filters.until.is_empty());
@@ -198,7 +198,7 @@ fn container_prune_filters_mixed() {
     let mut filters = ContainerPruneFilters::new();
     filters.until("24h".to_string());
     filters.label("test=example".to_string());
-    
+
     assert!(!filters.is_empty());
     assert_eq!(filters.until, vec!["24h"]);
     assert_eq!(filters.label, vec!["test=example"]);
@@ -210,7 +210,7 @@ fn container_prune_filters_serialization() {
     let mut filters = ContainerPruneFilters::new();
     filters.until("24h".to_string());
     filters.label("test=example".to_string());
-    
+
     let json = serde_json::to_string(&filters).unwrap();
     assert!(json.contains("until"));
     assert!(json.contains("label"));
@@ -222,7 +222,7 @@ fn container_prune_filters_serialization() {
 fn container_prune_filters_empty_serialization() {
     use crate::options::ContainerPruneFilters;
     let filters = ContainerPruneFilters::new();
-    
+
     let json = serde_json::to_string(&filters).unwrap();
     assert_eq!(json, "{}");
 }
@@ -231,7 +231,7 @@ fn container_prune_filters_empty_serialization() {
 fn pruned_containers_deserialization() {
     use crate::options::PrunedContainers;
     let json = r#"{"ContainersDeleted":["container1","container2"],"SpaceReclaimed":1024}"#;
-    
+
     let result: PrunedContainers = serde_json::from_str(json).unwrap();
     assert_eq!(result.containers_deleted, vec!["container1", "container2"]);
     assert_eq!(result.space_reclaimed, 1024);


### PR DESCRIPTION
## Summary
• Implements the missing `/containers/prune` Docker API endpoint wrapper
• Adds support for filtering containers by labels and time-based criteria
• Includes comprehensive test coverage and usage examples

## Changes
• **New `prune_containers` method** in `Docker` struct that accepts `ContainerPruneFilters`
• **`ContainerPruneFilters` struct** with support for `until` and `label` filtering
• **`PrunedContainers` response struct** containing deleted container IDs and reclaimed space
• **Unit tests** for filter serialization and response deserialization  
• **Integration tests** demonstrating filtering capabilities with Docker daemon
• **Usage example** in `examples/prune-containers.rs`

## Test plan
- [x] Unit tests pass for filter and response structs
- [x] Code compiles without errors
- [x] Integration tests created (run with `cargo test test_prune_containers -- --ignored`)
- [x] Example demonstrates various filtering scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)