### PR TITLE
CI: add a workflow to perform cargo publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,4 @@
-version: 2
-
-
-tag_filter: &tag_filter
-  tags:
-    only: /^\d+\.\d+\.\d+/
-  branches:
-    ignore: /.*/
+version: 2.1
 
 jobs:
   build_image:
@@ -131,16 +124,17 @@ workflows:
             - build_image
       - build_image
   publish:
+    when:
+      matches:
+        pattern: '^\d+\.\d+\.\d+'
+        value: << pipeline.git.tag >>
     jobs:
       - publish:
-          filters: *tag_filter
           requires:
             - build
       - build:
-          filters: *tag_filter
           requires:
             - build_image
-      - build_image:
-          filters: *tag_filter
+      - build_image
 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,15 +103,15 @@ jobs:
       - run:
           name: publish dockwoker (dryrun)
           command: |
-            cargo publish --dry-run --jobs ${BUILD_JOBS} --locked
+            cargo publish --dry-run --locked
       - run:
           name: publish dockwoker (dryrun)
           command: |
-            cargo publish --dry-run --jobs ${BUILD_JOBS} --locked
+            cargo publish --dry-run --locked
       - run:
           name: publish dockworker
           command: |
-            cargo publish --jobs ${BUILD_JOBS} --locked
+            cargo publish --locked
           env:
             CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,12 @@
 version: 2
+
+
+tag_filter: &tag_filter
+  tags:
+    only: /^\d+\.\d+\.\d+/
+  branches:
+    ignore: /.*/
+
 jobs:
   build_image:
     working_directory: /tmp/dockworker
@@ -104,6 +112,10 @@ jobs:
           command: |
             cargo publish --dry-run --jobs ${BUILD_JOBS} --locked
       - run:
+          name: publish dockwoker (dryrun)
+          command: |
+            cargo publish --dry-run --jobs ${BUILD_JOBS} --locked
+      - run:
           name: publish dockworker
           command: |
             cargo publish --jobs ${BUILD_JOBS} --locked
@@ -121,16 +133,14 @@ workflows:
   publish:
     jobs:
       - publish:
-          filters:
-            branches:
-              ignore: '/.*/'
-            tags:
-              only: '/^\d+\.\d+\.\d+/'
+          filters: *tag_filter
           requires:
             - build
       - build:
+          filters: *tag_filter
           requires:
             - build_image
-      - build_image
+      - build_image:
+          filters: *tag_filter
 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,30 @@ jobs:
             - ~/.cargo/registry/
             - target/debug
 
+  publish:
+    working_directory: /tmp/dockworker
+    docker:
+      - image: rust:1.83.0
+        environment:
+          DOCKER_VERSION: 28.0.0
+    steps:
+      - checkout
+      - run:
+          name: Setup Packages
+          command: |
+            apt-get update
+            apt-get install -y ca-certificates libssl-dev
+      - run:
+          name: publish dockwoker (dryrun)
+          command: |
+            cargo publish --dry-run --jobs ${BUILD_JOBS} --locked
+      - run:
+          name: publish dockworker
+          command: |
+            cargo publish --jobs ${BUILD_JOBS} --locked
+          env:
+            CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
 workflows:
   version: 2
   build_and_test:
@@ -94,4 +118,19 @@ workflows:
           requires:
             - build_image
       - build_image
+  publish:
+    jobs:
+      - publish:
+          filters:
+            branches:
+              ignore: '/.*/'
+            tags:
+              only: '/^\d+\.\d+\.\d+/'
+          requires:
+            - build
+      - build:
+          requires:
+            - build_image
+      - build_image
+
  


### PR DESCRIPTION
Added a workflow to perform cargo publish.
This workflow only runs when a tag matching `\d+\.\d+\.\d+` is pushed.