### PR TITLE
Fix: add tag filters match any pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,9 +132,18 @@ workflows:
       - publish:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - build:
           requires:
             - build_image
-      - build_image
+          filters:
+            tags:
+              only: /.*/
+      - build_image:
+          filters:
+            tags:
+              only: /.*/
 
  


### PR DESCRIPTION
The tag filter of 'when' clause of the workflow actually performs the filtering.

> https://circleci.com/docs/configuration-reference/#tags
> CircleCI does not run workflows for tags unless you explicitly specify
> tag filters. If a job requires any other jobs (directly or indirectly),
> you must specify tag filters for those jobs.